### PR TITLE
Create peildatum-periode-filtering.feature

### DIFF
--- a/features/partnerhistorie/peildatum-periode-filtering.feature
+++ b/features/partnerhistorie/peildatum-periode-filtering.feature
@@ -35,7 +35,7 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
       | naam  | waarde   |
       | datum | 20140315 |
-      En de 'partner' met de volgende historische gegevens
+      En de 'partner' heeft de volgende historische gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550003 |
       En de 'partner' heeft de volgende historische 'aangaanHuwelijkPartnerschap' gegevens
@@ -88,10 +88,7 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       En de persoon heeft een 'partner' met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550003 |
-      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
-      | naam  | waarde   |
-      | datum | 20140315 |
-      En de 'partner' met de volgende historische gegevens
+      En de 'partner' heeft de volgende historische gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550003 |
       En de 'partner' heeft de volgende historische 'aangaanHuwelijkPartnerschap' gegevens
@@ -129,99 +126,144 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       | peildatum           | 2016-10-21            |
       Dan heeft de response een lege array
 
-
-
-
     Scenario: Peildatum is gelijk aan Datum huwelijkssluiting/aangaan geregistreerd partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | peildatum           | 20171103                        |
+      | naam                | waarde                |
+      | type                | RaadpleegMetPeildatum |
+      | burgerservicenummer | 555550001             |
+      | fields              | burgerservicenummer   |
+      | peildatum           | 2017-11-03            |
       Dan heeft de response een partnerhistorie met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
 
     Scenario: Peildatum is gelijk aan Datum ontbinding huwelijk/geregistreerd partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | peildatum           | 20140315                        |
+      | naam                | waarde                |
+      | type                | RaadpleegMetPeildatum |
+      | burgerservicenummer | 555550001             |
+      | fields              | burgerservicenummer   |
+      | peildatum           | 2014-03-15            |
       Dan heeft de response een lege array
 
 Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleverd waarbij de Datum huwelijkssluiting/aangaan geregistreerd partnerschap niet op of na de datumTot ligt of de eventuele Datum ontbinding huwelijk/geregistreerd partnerschap niet voor of op de datumVan ligt.
 
     Scenario: Periode in actuele huwelijk/partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | datumVan            | 20180101                        |
-      | datumTot            | 20181231                        |
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 555550001           |
+      | fields              | burgerservicenummer |
+      | datumVan            | 2018-01-01          |
+      | datumTot            | 2018-12-31          |
       Dan heeft de response een partnerhistorie met  de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
 
     Scenario: Periode overlapt met actuele huwelijk/partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | datumVan            | 20160101                        |
-      | datumTot            | 20181231                        |
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 555550001           |
+      | fields              | burgerservicenummer |
+      | datumVan            | 2016-01-01          |
+      | datumTot            | 2018-12-31          |
       Dan heeft de response een partnerhistorie met  de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
 
     Scenario: Periode overlapt met ontbonden huwelijk/partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
+      En de 'partner' heeft de volgende historische gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende historische 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20101022 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | datumVan            | 20090101                        |
-      | datumTot            | 20131231                        |
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 555550001           |
+      | fields              | burgerservicenummer |
+      | datumVan            | 2009-01-01          |
+      | datumTot            | 2015-12-31          |
       Dan heeft de response een partnerhistorie met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550003 |
 
     Scenario: Periode overlapt met actuele en ontbonden huwelijk/partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
+      En de 'partner' heeft de volgende historische gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende historische 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20101022 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | datumVan            | 20110101                        |
-      | datumTot            | 20181231                        |
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 555550001           |
+      | fields              | burgerservicenummer |
+      | datumVan            | 2011-01-01          |
+      | datumTot            | 2018-12-31          |
       Dan heeft de response een partnerhistorie met  de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
@@ -230,18 +272,46 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | burgerservicenummer | 555550003 |
 
     Scenario: Periode overlapt met actuele en ontbonden huwelijken/partnerschappen
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
-      | 55        | 555550004                   | 19970703              | 20050828                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
+      En de 'partner' heeft de volgende historische gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende historische 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20101022 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550004 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20050828 |
+      En de 'partner' heeft de volgende historische gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende historische 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 19970703 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | datumVan            | 19990101                        |
-      | datumTot            | 20181231                        |
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 555550001           |
+      | fields              | burgerservicenummer |
+      | datumVan            | 1999-01-01          |
+      | datumTot            | 2018-12-31          |
       Dan heeft de response een partnerhistorie met  de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
@@ -253,56 +323,89 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | burgerservicenummer | 555550004 |
 
     Scenario: Periode voor huwelijkssluiting
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | datumVan            | 19990101                        |
-      | datumTot            | 20101231                        |
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 555550001           |
+      | fields              | burgerservicenummer |
+      | datumVan            | 1999-01-01          |
+      | datumTot            | 2010-12-31          |
       Dan heeft de response een lege array
 
     Scenario: Periode tussen twee partners
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
+      En de 'partner' heeft de volgende historische gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende historische 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20101022 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | datumVan            | 20150101                        |
-      | datumTot            | 20161231                        |
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 555550001           |
+      | fields              | burgerservicenummer |
+      | datumVan            | 2015-01-01          |
+      | datumTot            | 2016-12-31          |
       Dan heeft de response een lege array
 
     Scenario: datumTot is gelijk aan Datum huwelijkssluiting/aangaan geregistreerd partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | datumVan            | 20150101                        |
-      | datumTot            | 20171103                        |
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 555550001           |
+      | fields              | burgerservicenummer |
+      | datumVan            | 2015-01-01          |
+      | datumTot            | 2017-11-03          |
       Dan heeft de response een lege array
 
     Scenario: datumVan is gelijk aan Datum ontbinding huwelijk/geregistreerd partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | datumVan            | 20140315                        |
-      | datumTot            | 20161231                        |
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 555550001           |
+      | fields              | burgerservicenummer |
+      | datumVan            | 2014-03-15          |
+      | datumTot            | 2016-12-31          |
       Dan heeft de response een lege array

--- a/features/partnerhistorie/peildatum-periode-filtering.feature
+++ b/features/partnerhistorie/peildatum-periode-filtering.feature
@@ -1,0 +1,258 @@
+# language: nl
+
+@post-assert
+Functionaliteit: Selecteer het/de correcte (historische) huwelijken geregistreerde partnerschappen.
+
+Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waarbij de Datum huwelijkssluiting/aangaan geregistreerd partnerschap op of voor de peildatum ligt én de eventuele Datum ontbinding huwelijk/geregistreerd partnerschap na de peildatum.
+
+	Abstract Scenario: Peildatum in actuele huwelijk/partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | peildatum           | 20181017                        |
+      Dan heeft de response een partnerhistorie met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+
+	Scenario: Peildatum in ontbonden huwelijk/partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | peildatum           | 20120229                        |
+      Dan heeft de response een partnerhistorie met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+
+	Scenario: Persoon heeft nooit partner gehad
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft geen huwelijken/partnerschappen in de registratie
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | peildatum           | 20120229                        |
+      Dan heeft de response een lege array
+
+	Scenario: Peildatum na ontbinden huwelijk/partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | peildatum           | 20160813                        |
+      Dan heeft de response een lege array
+
+	Scenario: Peildatum voor huwelijkssluiting
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550003                   | 20101022              |                          | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | peildatum           | 19980923                        |
+      Dan heeft de response een lege array
+
+	Scenario: Peildatum tussen twee partners
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | peildatum           | 20161021                        |
+      Dan heeft de response een lege array
+
+	Scenario: Peildatum is gelijk aan Datum huwelijkssluiting/aangaan geregistreerd partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | peildatum           | 20171103                        |
+      Dan heeft de response een partnerhistorie met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+
+	Scenario: Peildatum is gelijk aan Datum ontbinding huwelijk/geregistreerd partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | peildatum           | 20140315                        |
+      Dan heeft de response een lege array
+
+Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleverd waarbij de Datum huwelijkssluiting/aangaan geregistreerd partnerschap niet op of na de datumTot ligt of de eventuele Datum ontbinding huwelijk/geregistreerd partnerschap niet voor of op de datumVan ligt.
+
+	Scenario: Periode in actuele huwelijk/partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | datumVan            | 20180101                        |
+      | datumTot            | 20181231                        |
+      Dan heeft de response een partnerhistorie met  de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+
+	Scenario: Periode overlapt met actuele huwelijk/partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | datumVan            | 20160101                        |
+      | datumTot            | 20181231                        |
+      Dan heeft de response een partnerhistorie met  de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+
+	Scenario: Periode overlapt met ontbonden huwelijk/partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | datumVan            | 20090101                        |
+      | datumTot            | 20131231                        |
+      Dan heeft de response een partnerhistorie met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+
+	Scenario: Periode overlapt met actuele en ontbonden huwelijk/partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | datumVan            | 20110101                        |
+      | datumTot            | 20181231                        |
+      Dan heeft de response een partnerhistorie met  de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En heeft de response een partnerhistorie met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+
+	Scenario: Periode overlapt met actuele en ontbonden huwelijken/partnerschappen
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      | 55        | 555550004                   | 19970703              | 20050828                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | datumVan            | 19990101                        |
+      | datumTot            | 20181231                        |
+      Dan heeft de response een partnerhistorie met  de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En heeft de response een partnerhistorie met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En heeft de response een partnerhistorie met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550004 |
+
+	Scenario: Periode voor huwelijkssluiting
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | datumVan            | 19990101                        |
+      | datumTot            | 20101231                        |
+      Dan heeft de response een lege array
+
+	Scenario: Periode tussen twee partners
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | datumVan            | 20150101                        |
+      | datumTot            | 20161231                        |
+      Dan heeft de response een lege array
+
+	Scenario: datumTot is gelijk aan Datum huwelijkssluiting/aangaan geregistreerd partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | datumVan            | 20150101                        |
+      | datumTot            | 20171103                        |
+      Dan heeft de response een lege array
+
+	Scenario: datumVan is gelijk aan Datum ontbinding huwelijk/geregistreerd partnerschap
+	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
+      | 5         | 555550002                   | 20171103              |                          | 
+      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Als partnerhistorie wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550001                       |
+      | fields              | burgerservicenummer             |
+      | datumVan            | 20140315                        |
+      | datumTot            | 20161231                        |
+      Dan heeft de response een lege array

--- a/features/partnerhistorie/peildatum-periode-filtering.feature
+++ b/features/partnerhistorie/peildatum-periode-filtering.feature
@@ -1,7 +1,7 @@
 # language: nl
 
 @post-assert
-Functionaliteit: Selecteer het/de correcte (historische) huwelijken geregistreerde partnerschappen.
+Functionaliteit: Selecteer (historische) huwelijken/geregistreerde partnerschappen.
 
 Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waarbij de Datum huwelijkssluiting/aangaan geregistreerd partnerschap op of voor de peildatum ligt én de eventuele Datum ontbinding huwelijk/geregistreerd partnerschap na de peildatum.
 

--- a/features/partnerhistorie/peildatum-periode-filtering.feature
+++ b/features/partnerhistorie/peildatum-periode-filtering.feature
@@ -5,82 +5,132 @@ Functionaliteit: Selecteer het/de correcte (historische) huwelijken geregistreer
 
 Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waarbij de Datum huwelijkssluiting/aangaan geregistreerd partnerschap op of voor de peildatum ligt én de eventuele Datum ontbinding huwelijk/geregistreerd partnerschap na de peildatum.
 
-    Abstract Scenario: Peildatum in actuele huwelijk/partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+    Scenario: Peildatum in actuele huwelijk/partnerschap
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | peildatum           | 20181017                        |
+      | naam                | waarde                |
+      | type                | RaadpleegMetPeildatum |
+      | burgerservicenummer | 555550001             |
+      | fields              | burgerservicenummer   |
+      | peildatum           | 2018-10-17            |
       Dan heeft de response een partnerhistorie met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
 
     Scenario: Peildatum in ontbonden huwelijk/partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
+      En de 'partner' met de volgende historische gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende historische 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20101022 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | peildatum           | 20120229                        |
+      | naam                | waarde                |
+      | type                | RaadpleegMetPeildatum |
+      | burgerservicenummer | 555550001             |
+      | fields              | burgerservicenummer   |
+      | peildatum           | 2012-02-29            |
       Dan heeft de response een partnerhistorie met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550003 |
 
     Scenario: Persoon heeft nooit partner gehad
-      Gegeven de persoon met burgerservicenummer 555550001 heeft geen huwelijken/partnerschappen in de registratie
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | peildatum           | 20120229                        |
+      | naam                | waarde                |
+      | type                | RaadpleegMetPeildatum |
+      | burgerservicenummer | 555550001             |
+      | fields              | burgerservicenummer   |
+      | peildatum           | 2012-02-29            |
       Dan heeft de response een lege array
 
     Scenario: Peildatum na ontbinden huwelijk/partnerschap
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | peildatum           | 20160813                        |
+      | naam                | waarde                |
+      | type                | RaadpleegMetPeildatum |
+      | burgerservicenummer | 555550001             |
+      | fields              | burgerservicenummer   |
+      | peildatum           | 2016-08-13            |
       Dan heeft de response een lege array
 
     Scenario: Peildatum voor huwelijkssluiting
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550003                   | 20101022              |                          | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
+      En de 'partner' met de volgende historische gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende historische 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20101022 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | peildatum           | 19980923                        |
+      | naam                | waarde                |
+      | type                | RaadpleegMetPeildatum |
+      | burgerservicenummer | 555550001             |
+      | fields              | burgerservicenummer   |
+      | peildatum           | 1998-09-23            |
       Dan heeft de response een lege array
 
     Scenario: Peildatum tussen twee partners
-      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
-      | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
-      | 5         | 555550002                   | 20171103              |                          | 
-      | 55        | 555550003                   | 20101022              | 20140315                 | 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550001 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550002 |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20171103 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+      | naam  | waarde   |
+      | datum | 20140315 |
       Als partnerhistorie wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 555550001                       |
-      | fields              | burgerservicenummer             |
-      | peildatum           | 20161021                        |
+      | naam                | waarde                |
+      | type                | RaadpleegMetPeildatum |
+      | burgerservicenummer | 555550001             |
+      | fields              | burgerservicenummer   |
+      | peildatum           | 2016-10-21            |
       Dan heeft de response een lege array
+
+
+
 
     Scenario: Peildatum is gelijk aan Datum huwelijkssluiting/aangaan geregistreerd partnerschap
       Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie

--- a/features/partnerhistorie/peildatum-periode-filtering.feature
+++ b/features/partnerhistorie/peildatum-periode-filtering.feature
@@ -5,8 +5,8 @@ Functionaliteit: Selecteer het/de correcte (historische) huwelijken geregistreer
 
 Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waarbij de Datum huwelijkssluiting/aangaan geregistreerd partnerschap op of voor de peildatum ligt én de eventuele Datum ontbinding huwelijk/geregistreerd partnerschap na de peildatum.
 
-	Abstract Scenario: Peildatum in actuele huwelijk/partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Abstract Scenario: Peildatum in actuele huwelijk/partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -20,8 +20,8 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
 
-	Scenario: Peildatum in ontbonden huwelijk/partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Peildatum in ontbonden huwelijk/partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -35,8 +35,8 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       | naam                | waarde    |
       | burgerservicenummer | 555550003 |
 
-	Scenario: Persoon heeft nooit partner gehad
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft geen huwelijken/partnerschappen in de registratie
+    Scenario: Persoon heeft nooit partner gehad
+      Gegeven de persoon met burgerservicenummer 555550001 heeft geen huwelijken/partnerschappen in de registratie
       Als partnerhistorie wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -45,8 +45,8 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       | peildatum           | 20120229                        |
       Dan heeft de response een lege array
 
-	Scenario: Peildatum na ontbinden huwelijk/partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Peildatum na ontbinden huwelijk/partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550003                   | 20101022              | 20140315                 | 
       Als partnerhistorie wordt gezocht met de volgende parameters
@@ -57,8 +57,8 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       | peildatum           | 20160813                        |
       Dan heeft de response een lege array
 
-	Scenario: Peildatum voor huwelijkssluiting
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Peildatum voor huwelijkssluiting
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550003                   | 20101022              |                          | 
       Als partnerhistorie wordt gezocht met de volgende parameters
@@ -69,8 +69,8 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       | peildatum           | 19980923                        |
       Dan heeft de response een lege array
 
-	Scenario: Peildatum tussen twee partners
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Peildatum tussen twee partners
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -82,8 +82,8 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       | peildatum           | 20161021                        |
       Dan heeft de response een lege array
 
-	Scenario: Peildatum is gelijk aan Datum huwelijkssluiting/aangaan geregistreerd partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Peildatum is gelijk aan Datum huwelijkssluiting/aangaan geregistreerd partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -97,8 +97,8 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
 
-	Scenario: Peildatum is gelijk aan Datum ontbinding huwelijk/geregistreerd partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Peildatum is gelijk aan Datum ontbinding huwelijk/geregistreerd partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -112,8 +112,8 @@ Rule: Bij vragen van partnerhistorie op peildatum wordt de partner geleverd waar
 
 Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleverd waarbij de Datum huwelijkssluiting/aangaan geregistreerd partnerschap niet op of na de datumTot ligt of de eventuele Datum ontbinding huwelijk/geregistreerd partnerschap niet voor of op de datumVan ligt.
 
-	Scenario: Periode in actuele huwelijk/partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Periode in actuele huwelijk/partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -128,8 +128,8 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
 
-	Scenario: Periode overlapt met actuele huwelijk/partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Periode overlapt met actuele huwelijk/partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -144,8 +144,8 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
 
-	Scenario: Periode overlapt met ontbonden huwelijk/partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Periode overlapt met ontbonden huwelijk/partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -160,8 +160,8 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | naam                | waarde    |
       | burgerservicenummer | 555550003 |
 
-	Scenario: Periode overlapt met actuele en ontbonden huwelijk/partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Periode overlapt met actuele en ontbonden huwelijk/partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -179,8 +179,8 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | naam                | waarde    |
       | burgerservicenummer | 555550003 |
 
-	Scenario: Periode overlapt met actuele en ontbonden huwelijken/partnerschappen
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Periode overlapt met actuele en ontbonden huwelijken/partnerschappen
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -202,8 +202,8 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | naam                | waarde    |
       | burgerservicenummer | 555550004 |
 
-	Scenario: Periode voor huwelijkssluiting
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Periode voor huwelijkssluiting
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       Als partnerhistorie wordt gezocht met de volgende parameters
@@ -215,8 +215,8 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | datumTot            | 20101231                        |
       Dan heeft de response een lege array
 
-	Scenario: Periode tussen twee partners
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: Periode tussen twee partners
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -229,8 +229,8 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | datumTot            | 20161231                        |
       Dan heeft de response een lege array
 
-	Scenario: datumTot is gelijk aan Datum huwelijkssluiting/aangaan geregistreerd partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: datumTot is gelijk aan Datum huwelijkssluiting/aangaan geregistreerd partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 
@@ -243,8 +243,8 @@ Rule: Bij vragen van partnerhistorie op periode worden alleen de partners geleve
       | datumTot            | 20171103                        |
       Dan heeft de response een lege array
 
-	Scenario: datumVan is gelijk aan Datum ontbinding huwelijk/geregistreerd partnerschap
-	  Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
+    Scenario: datumVan is gelijk aan Datum ontbinding huwelijk/geregistreerd partnerschap
+      Gegeven de persoon met burgerservicenummer 555550001 heeft de volgende huwelijken/partnerschappen in de registratie
       | Categorie | Burgerservicenummer (01.20) | Datum aangaan (06.10) | Datum ontbinding (07.10) | 
       | 5         | 555550002                   | 20171103              |                          | 
       | 55        | 555550003                   | 20101022              | 20140315                 | 


### PR DESCRIPTION
De feature bestanden in de folder 'features' verwijderen we op een later moment.

De scenario's zijn zo minimalistisch gehouden vandaar dat in de 'fields' parameter steeds alleen het 'burgerservicenummer' is opgenomen. Indien dat voor de duidelijkheid gewenst is heb ik ook nog een versie waarin daar ook 'aangaanHuwelijkPartnerschap' en 'ontbindingHuwelijkPartnerschap' is opgenomen.

Zie ook mijn opmerking/vraag in [issue 1205](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/issues/1205).