### PR TITLE
toevoegen datumTot in GbaNationaliteit

### DIFF
--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -1529,6 +1529,9 @@
           "datumIngangGeldigheid" : {
             "$ref" : "#/components/schemas/GbaDatum"
           },
+          "datumTot" : {
+            "$ref" : "#/components/schemas/GbaDatum"
+          },
           "nationaliteit" : {
             "$ref" : "#/components/schemas/Waardetabel"
           },

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -1158,6 +1158,8 @@ components:
           type: string
         datumIngangGeldigheid:
           $ref: '#/components/schemas/GbaDatum'
+        datumTot:
+          $ref: '#/components/schemas/GbaDatum'
         nationaliteit:
           $ref: '#/components/schemas/Waardetabel'
         redenOpname:

--- a/specificatie/nationaliteit.yaml
+++ b/specificatie/nationaliteit.yaml
@@ -99,6 +99,8 @@ components:
           pattern: ^(B|V)$
         datumIngangGeldigheid:
           $ref: 'datum.yaml#/components/schemas/GbaDatum'
+        datumTot:
+          $ref: 'datum.yaml#/components/schemas/GbaDatum'
         nationaliteit:
           $ref: 'common.yaml#/components/schemas/Waardetabel'
         redenOpname:


### PR DESCRIPTION
in #78 is ten onrechte datumTot verwijderd uit de GbaNationaliteit. Dit is ten onrechte in [#1199](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/issues/1199) bestempeld als een informatievraag.

De juristen van RvIG/BZK hebben dit niet als informatievraag bestempeld.

We nemen hetzelfde gegeven uit het LO, namelijk ingangsdatum geldigheid (85.10), meerdere keren op. Dit is het geval wanneer in de BRP op de nationaliteitgegevens meerdere ingangsdatum geldigheid zijn geregistreerd. Dat is het geval bij een beëindigde nationaliteit. 
Per gebeurtenis -opnemen en beëindigen van de nationaliteit- is er in de BRP dan een ingangsdatum geldigheid opgenomen. Veld datumTot wordt dan gevuld met de ingangsdatum geldigheid (85.10) van de beëindiging. Veld ingangsdatum geldigheid wordt gevuld met ingangsdatum geldigheid (85.10) van de opname van de nationaliteit. Het gaat dus niet om bewerken van gegevens, maar om selectie van gegevens.